### PR TITLE
Provides additional configuration options: hostname, project root, endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,18 +13,16 @@ dependencies:
 +    github: honeybadger-io/honeybadger-crystal
 ```
 
-Add the Honeybadger::Handler to the `HTTP::Server` stack:
+Add the `Honeybadger::Handler` to the `HTTP::Server` stack:
 
 ```crystal
 honeybadger_api_key = ENV["HONEYBADGER_API_KEY"]? || "00000000"
-honeybadger_enabled = MyServer.production?
 
 Honeybadger.configure(api_key: honeybadger_api_key)
 
-Honeybadger::Handler.new(
-  enabled: honeybadger_enabled,
-  factory: Honeybadger::Payload
-)
+HTTP::Server.new([Honeybadger::Handler.new]) do |context|
+  # ...
+end
 ```
 
 Details for adding the handler to:
@@ -32,15 +30,45 @@ Details for adding the handler to:
 - [Lucky Framework](https://luckyframework.org/guides/http-and-routing/http-handlers)
 - [Amber Framework](https://docs.amberframework.org/amber/guides/routing/pipelines#sharing-pipelines)
 
-You can also manually report exceptions to Honeybadger like so:
+### Reporting exceptions
+
+For non-web contexts, manually report exceptions to Honeybadger like so:
 
 ```crystal
 begin
+  # run application code
   raise "OH NO!"
 rescue exception
   Honeybadger.notify(exception)
 end
 ```
+
+## Configuration
+
+To set configuration options, use the `Honeybadger.configure` method. For the default, out of the box configuration, provide the API key:
+
+```crystal
+Honeybadger.configure("your api key")
+```
+
+For more configuration options, you can get access to the entire configuration object with a block:
+
+```crystal
+Honeybadger.configure do |settings|
+  settings.api_key = "your api key"
+  settings.hostname = "badger"
+end
+```
+
+The following configuration options are available:
+
+|  Name | Type | Default | Example |
+| ----- | ---- | ------- | ------- |
+| api_key | String | `""` | `"badgers"` |
+| endpoint | Path|String | `"https://api.honeybadger.io"` | `"https://honeybadger.example.com/"` |
+| hostname | String | The hostname of the current server. | `"badger"` |
+| project_root | String | The current working directory | `"/path/to/project"` |
+| report_data | `bool` | `true` | `false` |
 
 ## Version Requirements
 

--- a/spec/honeybadger/configuration_spec.cr
+++ b/spec/honeybadger/configuration_spec.cr
@@ -1,0 +1,66 @@
+require "../spec_helper"
+
+require "file_utils"
+
+describe Honeybadger::Configuration do
+  describe "#configure" do
+    it "allows setting and retrieving the api key" do
+      new_api_key = "abcdefg"
+
+      protect_configuration do
+        Honeybadger.configuration.api_key = new_api_key
+        Honeybadger.api_key.should eq new_api_key
+      end
+    end
+
+    it "has an endpoint configuration" do
+      Honeybadger.endpoint.to_s.should eq "https://api.honeybadger.io"
+
+      protect_configuration do
+        alternate_endpoint = Path["https://honeybadger.example.com"]
+        Honeybadger.configuration.endpoint = alternate_endpoint
+        Honeybadger.endpoint.to_s.should eq alternate_endpoint.to_s
+      end
+
+      # configure endpoint with string
+      protect_configuration do
+        alternate_endpoint = "https://honeybadger.example.com"
+        Honeybadger.configuration.endpoint = alternate_endpoint
+        Honeybadger.endpoint.to_s.should eq alternate_endpoint
+      end
+    end
+
+    it "populates the git_revision" do
+      Honeybadger.git_revision.should_not be ""
+    end
+
+    it "populates the hostname" do
+      Honeybadger.hostname.should_not be ""
+
+      protect_configuration do
+        a_hostname = "example_hostname"
+        Honeybadger.configuration.hostname = a_hostname
+        Honeybadger.hostname.should eq a_hostname
+      end
+    end
+
+    it "populates the project_root" do
+      Honeybadger.project_root.should eq FileUtils.pwd
+
+      protect_configuration do
+        path = "/"
+        Honeybadger.configuration.project_root = path
+        Honeybadger.project_root.should eq path
+      end
+    end
+
+    it "has report_data" do
+      Honeybadger.report_data?.should be_true
+
+      protect_configuration do
+        Honeybadger.configuration.report_data = false
+        Honeybadger.report_data?.should be_false
+      end
+    end
+  end
+end

--- a/spec/honeybadger/configuration_spec.cr
+++ b/spec/honeybadger/configuration_spec.cr
@@ -30,8 +30,8 @@ describe Honeybadger::Configuration do
       end
     end
 
-    it "populates the git_revision" do
-      Honeybadger.git_revision.should_not be ""
+    it "populates the revision" do
+      Honeybadger.revision.should_not be ""
     end
 
     it "populates the hostname" do

--- a/spec/honeybadger/http_payload_spec.cr
+++ b/spec/honeybadger/http_payload_spec.cr
@@ -1,21 +1,6 @@
 require "../spec_helper"
-require "file_utils"
 
 describe Honeybadger::HttpPayload do
-  describe "compile time data collection" do
-    it "populates the compile_dir" do
-      Honeybadger::HttpPayload::COMPILE_DIR.should eq FileUtils.pwd
-    end
-
-    it "populates the hostname" do
-      Honeybadger::HttpPayload::HOSTNAME.should_not be ""
-    end
-
-    it "populates the git_revision" do
-      Honeybadger::HttpPayload::GIT_REVISION.should_not be ""
-    end
-  end
-
   describe "to_json" do
     it "embeds the request path" do
       expected_request_path = "/honeybadger/crystal"

--- a/spec/honeybadger_spec.cr
+++ b/spec/honeybadger_spec.cr
@@ -1,4 +1,5 @@
 require "./spec_helper"
+
 require "yaml"
 
 describe Honeybadger do
@@ -10,15 +11,24 @@ describe Honeybadger do
     end
   end
 
-  describe "#configure" do
-    it "allows setting and retrieving the api key" do
-      old_api_key = Honeybadger.api_key
-      new_api_key = "12345"
+  describe "#configure with a block" do
+    it "yields an instance of Configuration" do
+      Honeybadger.configure do |settings|
+        settings.should be_a Honeybadger::Configuration
+      end
+    end
+  end
 
+  describe "#configure without a block" do
+    protect_configuration do
+      Honeybadger.configure("000000", report_data: false)
+      Honeybadger.report_data?.should be_false
+    end
+
+    protect_configuration do
+      new_api_key = "12345"
       Honeybadger.configure api_key: new_api_key
       Honeybadger.api_key.should eq new_api_key
-
-      Honeybadger.configure api_key: old_api_key
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -3,6 +3,7 @@ require "../src/honeybadger"
 
 require "./support/example_payload"
 require "./support/mock_http"
+require "./support/configuration_isolater"
 
 def example_payload
   Honeybadger::ExamplePayload.new Exception.new

--- a/spec/support/configuration_isolater.cr
+++ b/spec/support/configuration_isolater.cr
@@ -1,0 +1,24 @@
+module Honeybadger
+  class_setter configuration : Configuration
+end
+
+def protect_configuration
+  pristine_configuration = Honeybadger.configuration.dup
+  yield
+  Honeybadger.configuration = pristine_configuration
+end
+
+describe "protect_configuration" do
+  it "protects the configuration" do
+    pristine_configuration = Honeybadger.configuration
+    good_key = pristine_configuration.api_key
+
+    protect_configuration do
+      bad_key = good_key + "test leakage"
+      Honeybadger.configuration.api_key = bad_key
+      Honeybadger.api_key.should eq bad_key
+    end
+
+    Honeybadger.api_key.should eq good_key
+  end
+end

--- a/spec/support/protect_configuration.cr
+++ b/spec/support/protect_configuration.cr
@@ -1,0 +1,25 @@
+module Honeybadger
+  class_setter configuration : Configuration
+end
+
+def protect_configuration
+  pristine_configuration = Honeybadger.configuration.dup
+  yield
+  Honeybadger.configuration = pristine_configuration
+end
+
+describe "protect_configuration" do
+  it "protects the configuration" do
+    pristine_configuration = Honeybadger.configuration
+    good_key = pristine_configuration.api_key
+    assert false
+
+    protect_configuration do
+      bad_key = good_key + "test leakage"
+      Honeybadger.configuration.api_key = bad_key
+      Honeybadger.api_key.should eq bad_key
+    end
+
+    Honeybadger.api_key.should eq good_key
+  end
+end

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -11,7 +11,7 @@ module Honeybadger
     property endpoint : Path = Path["https://api.honeybadger.io"]
 
     # The project git revision. Evaluated at compile time.
-    getter git_revision : String = {{ run("./run_macros/git_revision.cr").stringify }}.strip
+    getter revision : String = {{ run("./run_macros/git_revision.cr").stringify }}.strip
 
     # The system or container hostname.
     property hostname : String = System.hostname
@@ -57,7 +57,7 @@ module Honeybadger
     yield configuration
   end
 
-  {% for method in [:api_key, :endpoint, :project_root, :git_revision, :hostname]%}
+  {% for method in [:api_key, :endpoint, :project_root, :revision, :hostname]%}
     # Alias of `Configuration.{{ method.id }}`.
     def self.{{ method.id }}
       configuration.{{ method.id }}

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -3,30 +3,70 @@ require "./honeybadger/*"
 module Honeybadger
   VERSION = "0.1.0"
 
-  @@api_key = ""
-  @@report_data = true
+  class Configuration
+    # A Honeybadger API key.
+    property api_key = ""
+
+    # The API endpoint for sending Honeybadger payloads.
+    property endpoint : Path = Path["https://api.honeybadger.io"]
+
+    # The project git revision. Evaluated at compile time.
+    getter git_revision : String = {{ run("./run_macros/git_revision.cr").stringify }}.strip
+
+    # The system or container hostname.
+    property hostname : String = System.hostname
+
+    # The path to the projects source code. Evaluated at compile time.
+    property project_root : String = {{ run("./run_macros/pwd.cr").stringify }}.strip
+
+    # Send data to the Honeybadger collector
+    property report_data = true
+
+    def endpoint=(path : String) : String
+      @endpoint = Path[path]
+      path
+    end
+  end
+
+  # The Honeybadger Configuration singleton instance.
+  class_getter configuration = Configuration.new
 
   # Set the API key to be used for calls to the honeybadger API.
-  # Call `configure` during application pre-boot:
+  # Call `configure` during an application boot sequence and populate the api key:
   #
   # ```
   #   honeybadger_api_key = ENV["HONEYBADGER_API_KEY"]? || "00000000"
-  #   honeybadger_enabled = true
-  #
   #   Honeybadger.configure(api_key: honeybadger_api_key)
   # ```
-  def self.configure(api_key : String, report_data = true) : Nil
-    @@api_key = api_key
-    @@report_data = report_data
+  def self.configure(api_key : String, *, report_data = true) : Nil
+    configure do |s|
+      s.api_key = api_key
+      s.report_data = report_data
+    end
   end
 
-  # :nodoc:
-  def self.api_key
-    @@api_key
+  # Configure Honeybadger with a block.
+  #
+  # ```
+  # Honeybadger.configure do |settings|
+  #   settings.api_key = "00000"
+  #   settings.project_root = "/path/to/project"
+  # end
+  # ```
+  def self.configure(&block) : Nil
+    yield configuration
   end
 
+  {% for method in [:api_key, :endpoint, :project_root, :git_revision, :hostname]%}
+    # Alias of `Configuration.{{ method.id }}`.
+    def self.{{ method.id }}
+      configuration.{{ method.id }}
+    end
+  {% end %}
+
+  # Alias of `Configuration.report_data`
   def self.report_data? : Bool
-    @@report_data
+    configuration.report_data
   end
 
   def self.notify(exception : Exception) : Nil

--- a/src/honeybadger/api.cr
+++ b/src/honeybadger/api.cr
@@ -1,8 +1,6 @@
 module Honeybadger
   # An API wrapper for the Honeybadger HTTP API
   class Api
-    BASE_URL = Path["https://api.honeybadger.io"]
-
     # :nodoc:
     def initialize
     end
@@ -23,7 +21,7 @@ module Honeybadger
 
     # :nodoc:
     private def request(path : String, message_body : String)
-      endpoint = BASE_URL.join path
+      endpoint = Honeybadger.endpoint.join path
       HTTP::Client.post endpoint.to_s, request_headers, body: message_body
     end
   end

--- a/src/honeybadger/payload.cr
+++ b/src/honeybadger/payload.cr
@@ -5,15 +5,6 @@ module Honeybadger
   # This payload provides a baseline for general use and is intended
   # to be extended by framework or application specific uses to fill in details.
   class Payload
-    # The path to source code at compile time.
-    COMPILE_DIR  = {{ run("../run_macros/pwd.cr").stringify }}.strip
-
-    # The git revision at compile time.
-    GIT_REVISION = {{ run("../run_macros/git_revision.cr").stringify }}.strip
-
-    # The system or container hostname.
-    HOSTNAME     = System.hostname
-
     # The exception to be rendered.
     getter exception : Exception
 
@@ -101,17 +92,17 @@ module Honeybadger
     private def server_json(builder)
       builder.field "server" do
         builder.object do
-          builder.field "project_root", COMPILE_DIR
+          builder.field "project_root", Honeybadger.project_root
 
           if env = environment_name
             builder.field "environment_name", env
           end
 
-          if hostname = HOSTNAME
+          if hostname = Honeybadger.hostname
             builder.field "hostname", hostname
           end
 
-          if revision = GIT_REVISION
+          if revision = Honeybadger.git_revision
             builder.field "revision", revision
           end
 

--- a/src/honeybadger/payload.cr
+++ b/src/honeybadger/payload.cr
@@ -102,7 +102,7 @@ module Honeybadger
             builder.field "hostname", hostname
           end
 
-          if revision = Honeybadger.git_revision
+          if revision = Honeybadger.revision
             builder.field "revision", revision
           end
 


### PR DESCRIPTION
This:

- implements a configuration singleton object
- centralizes pre-existing configuration options for endpoint, hostname, git rev
- implements a block style configuration method
- adds a configuration section to the readme

Included are docs and tests for all of the above.

Fixes #10, Fixes #2 and paves some road for #3, #8, and #9