### PR TITLE
Development environments configurations

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ The following configuration options are available:
 | project_root | String | The current working directory | `"/path/to/project"` |
 | report_data | `bool` | `true` | `false` |
 | development_environments | Array(String) | ["development","test"] | |
-| environment | String | `"production"` | |
+| environment | String? | `nil` | `"production"` |
 
 ## Version Requirements
 

--- a/README.md
+++ b/README.md
@@ -69,6 +69,8 @@ The following configuration options are available:
 | hostname | String | The hostname of the current server. | `"badger"` |
 | project_root | String | The current working directory | `"/path/to/project"` |
 | report_data | `bool` | `true` | `false` |
+| development_environment | Array(String) | ["development","test"] | |
+| environment | String | `"production"` | |
 
 ## Version Requirements
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ The following configuration options are available:
 | hostname | String | The hostname of the current server. | `"badger"` |
 | project_root | String | The current working directory | `"/path/to/project"` |
 | report_data | `bool` | `true` | `false` |
-| development_environment | Array(String) | ["development","test"] | |
+| development_environments | Array(String) | ["development","test"] | |
 | environment | String | `"production"` | |
 
 ## Version Requirements

--- a/spec/honeybadger/configuration_spec.cr
+++ b/spec/honeybadger/configuration_spec.cr
@@ -115,7 +115,7 @@ describe Honeybadger::Configuration do
         end
       end
 
-      it "allows setting the development environment" do
+      it "allows setting the current environment" do
         protect_configuration do
           Honeybadger.configure("xxxx", environment: "honeybadger_test")
           Honeybadger.configuration.environment.should eq "honeybadger_test"
@@ -128,6 +128,10 @@ describe Honeybadger::Configuration do
 
           Honeybadger.configuration.environment.should eq "honeybadger_development"
         end
+      end
+
+      it "defaults to a nil environment name" do
+        Honeybadger.configuration.environment.should be_nil
       end
 
       it "defaults to not a development environment" do

--- a/spec/honeybadger/configuration_spec.cr
+++ b/spec/honeybadger/configuration_spec.cr
@@ -73,7 +73,7 @@ describe Honeybadger::Configuration do
             config.development_environments = ["dont_send_data"]
             config.environment = "send_data"
 
-            # but the report data is true
+            # but the report data is false
             config.report_data = false
           end
 

--- a/spec/honeybadger/configuration_spec.cr
+++ b/spec/honeybadger/configuration_spec.cr
@@ -54,13 +54,86 @@ describe Honeybadger::Configuration do
       end
     end
 
-    it "has report_data" do
-      Honeybadger.report_data?.should be_true
+    describe "report_data" do
+      it "allows setting the report_data variable" do
+        protect_configuration do
+          Honeybadger.configuration.report_data = false
+          Honeybadger.report_data?.should be_false
+        end
+      end
 
-      protect_configuration do
-        Honeybadger.configuration.report_data = false
-        Honeybadger.report_data?.should be_false
+      it "defaults to true" do
+        Honeybadger.report_data?.should be_true
+      end
+
+      it "overrides development environments" do
+        protect_configuration do
+          Honeybadger.configure do |config|
+            # when the environments "look like production"
+            config.development_environments = ["dont_send_data"]
+            config.environment = "send_data"
+
+            # but the report data is true
+            config.report_data = false
+          end
+
+          Honeybadger.report_data?.should be_false
+        end
+
+        protect_configuration do
+          Honeybadger.configure do |config|
+            # when the environment "look like development"
+            config.development_environments = ["dont_send_data"]
+            config.environment = "dont_send_data"
+
+            # but the report data flag is true
+            config.report_data = true
+          end
+
+          Honeybadger.report_data?.should be_true
+        end
       end
     end
+
+    describe "environments" do
+      it "defaults development and test to be develpment environments" do
+        protect_configuration do
+          ["development","test"].each do |tested_env|
+            Honeybadger.configuration.environment = tested_env
+            Honeybadger.configuration.development?.should be_true
+          end
+        end
+      end
+
+      it "allows overriding the development environments" do
+        protect_configuration do
+          Honeybadger.configure do |configure|
+            configure.development_environments = ["test"]
+          end
+
+          Honeybadger.configuration.development_environments.should eq ["test"]
+        end
+      end
+
+      it "allows setting the development environment" do
+        protect_configuration do
+          Honeybadger.configure("xxxx", environment: "honeybadger_test")
+          Honeybadger.configuration.environment.should eq "honeybadger_test"
+        end
+
+        protect_configuration do
+          Honeybadger.configure do |config|
+            config.environment = "honeybadger_development"
+          end
+
+          Honeybadger.configuration.environment.should eq "honeybadger_development"
+        end
+      end
+
+      it "defaults to not a development environment" do
+        Honeybadger.configuration.development?.should be_false
+      end
+    end
+
   end
 end

--- a/spec/honeybadger/payload_spec.cr
+++ b/spec/honeybadger/payload_spec.cr
@@ -1,8 +1,7 @@
 require "../spec_helper"
 
 private def rendered_and_parsed_payload
-  rendered = Honeybadger::ExamplePayload.new.to_json
-  JSON.parse(rendered)
+  JSON.parse Honeybadger::ExamplePayload.new.to_json
 end
 
 describe Honeybadger::Payload do
@@ -56,8 +55,11 @@ describe Honeybadger::Payload do
       rendered_and_parsed_payload["server"]["pid"].as_i?.should be_a Int32
     end
 
-    it "has the environment" do
-      rendered_and_parsed_payload["server"]["environment_name"].as_s?.should eq Honeybadger.configuration.environment
+    it "has the environment when it's available" do
+      protect_configuration do
+        Honeybadger.configuration.environment = "honeybadger_tests"
+        rendered_and_parsed_payload["server"]["environment_name"].as_s?.should eq Honeybadger.configuration.environment
+      end
     end
   end
 end

--- a/spec/honeybadger/payload_spec.cr
+++ b/spec/honeybadger/payload_spec.cr
@@ -57,7 +57,7 @@ describe Honeybadger::Payload do
     end
 
     it "has the environment" do
-      rendered_and_parsed_payload["server"]["environment_name"].as_s?.should eq "testing environment"
+      rendered_and_parsed_payload["server"]["environment_name"].as_s?.should eq Honeybadger.configuration.environment
     end
   end
 end

--- a/spec/honeybadger_spec.cr
+++ b/spec/honeybadger_spec.cr
@@ -21,8 +21,8 @@ describe Honeybadger do
 
   describe "#configure without a block" do
     protect_configuration do
-      Honeybadger.configure("000000", report_data: false)
-      Honeybadger.report_data?.should be_false
+      Honeybadger.configure("000000", environment: "development")
+      Honeybadger.configuration.environment.should eq "development"
     end
 
     protect_configuration do

--- a/spec/support/example_payload.cr
+++ b/spec/support/example_payload.cr
@@ -9,9 +9,5 @@ module Honeybadger
     rescue e
       return e
     end
-
-    def environment_name
-      "testing environment"
-    end
   end
 end

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -14,7 +14,7 @@ module Honeybadger
     property endpoint : Path = Path["https://api.honeybadger.io"]
 
     # The app environment
-    property environment : String = "production"
+    property environment : String? = nil
 
     # The project git revision. Evaluated at compile time.
     getter revision : String = {{ run("./run_macros/git_revision.cr").stringify }}.strip
@@ -37,7 +37,12 @@ module Honeybadger
     end
 
     def development? : Bool
-      development_environments.includes? environment
+      if env = environment
+        development_environments.includes? environment
+      else
+        # if the environment is nil, it's never development
+        false
+      end
     end
 
     # When report_data is unset, default to development? logic.

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -7,8 +7,14 @@ module Honeybadger
     # A Honeybadger API key.
     property api_key = ""
 
+    # The list of environments considered "development"
+    property development_environments : Array(String) = ["development", "test"]
+
     # The API endpoint for sending Honeybadger payloads.
     property endpoint : Path = Path["https://api.honeybadger.io"]
+
+    # The app environment
+    property environment : String = "production"
 
     # The project git revision. Evaluated at compile time.
     getter revision : String = {{ run("./run_macros/git_revision.cr").stringify }}.strip
@@ -19,12 +25,31 @@ module Honeybadger
     # The path to the projects source code. Evaluated at compile time.
     property project_root : String = {{ run("./run_macros/pwd.cr").stringify }}.strip
 
-    # Send data to the Honeybadger collector
-    property report_data = true
+    # Explicitly override the development environment check.
+    # Nil = check for development environment
+    # True = always report data
+    # False = never report data
+    property report_data : Bool? = nil
 
     def endpoint=(path : String) : String
       @endpoint = Path[path]
       path
+    end
+
+    def development? : Bool
+      development_environments.includes? environment
+    end
+
+    # When report_data is unset, default to development? logic.
+    def report_data? : Bool
+      case @report_data
+      when nil
+        ! development?
+      when true
+        true
+      else
+        false
+      end
     end
   end
 
@@ -38,10 +63,10 @@ module Honeybadger
   #   honeybadger_api_key = ENV["HONEYBADGER_API_KEY"]? || "00000000"
   #   Honeybadger.configure(api_key: honeybadger_api_key)
   # ```
-  def self.configure(api_key : String, *, report_data = true) : Nil
+  def self.configure(api_key : String, *, environment : String? = nil) : Nil
     configure do |s|
       s.api_key = api_key
-      s.report_data = report_data
+      s.environment = environment if environment
     end
   end
 
@@ -66,7 +91,7 @@ module Honeybadger
 
   # Alias of `Configuration.report_data`
   def self.report_data? : Bool
-    configuration.report_data
+    configuration.report_data?
   end
 
   def self.notify(exception : Exception) : Nil

--- a/src/honeybadger/payload.cr
+++ b/src/honeybadger/payload.cr
@@ -17,9 +17,6 @@ module Honeybadger
     # details into the payload.
     def request_json(builder); end
 
-    # Stub implemented to provide the environment name, e.g. "production"
-    def environment_name; end
-
     # Renders the complete json payload.
     def to_json(builder : JSON::Builder)
       builder.object do
@@ -94,7 +91,7 @@ module Honeybadger
         builder.object do
           builder.field "project_root", Honeybadger.project_root
 
-          if env = environment_name
+          if env = Honeybadger.configuration.environment
             builder.field "environment_name", env
           end
 


### PR DESCRIPTION
fixes #9 and #8 

Provides both a "current environment" config setting for the api payload as well as configuration to select development environments. `report_data?` now behaves according to the Client Library Spec as well.

I also rewired the terse `Honeybadger.configure` method so that it takes an environment name instead of report_data parameter. The latter can still be accessed via the block form of configuration if needed.