### PR TITLE
Allow to be used with Crystal 1.0

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -4,7 +4,7 @@ version: 0.1.0
 authors:
   - robacarp
 
-crystal: 0.36.1
+crystal: ">= 0.36.1, < 2.0.0"
 
 targets:
   demo:


### PR DESCRIPTION
The `crystal: 0.36.1` annotation is interpreted as `~> 0.36, >= 0.36.1`, which is unfortunately incompatible with Crystal 1.0.

This patch allows it to be used with 0.36.1 and 1.x.