### PR TITLE
minimum POC for context api

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,0 +1,15 @@
+# Change Log
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [0.1.1] - 2021-06-29
+### Added
+- Allows Honeybadger configuration for development environments to be specified (#13)
+- Updated crystal version specifier to allow Honeybadger to be used with Crystal 1.0. (#15)
+- Allows Honeybadger config to be specified with environment variables (#16)
+- Honeybadger.notify now accepts an optional second argument to specify the error context. (#17)
+
+## [0.1.0] - 2021-04-13
+- Initial crystal shard release

--- a/CHANGELOG
+++ b/CHANGELOG
@@ -4,6 +4,8 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
 ## [0.1.1] - 2021-06-29
 ### Added
 - Allows Honeybadger configuration for development environments to be specified (#13)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,10 @@
 
 `HTTP::Handler` and exception notifier for the :zap: [Honeybadger error notifier](https://www.honeybadger.io/).
 
+## Resources
+
+The change log for this shard is included in this repository: https://github.com/honeybadger-io/honeybadger-crystal/blob/main/CHANGELOG.md
+
 ## Getting Started
 
 Update your `shard.yml` to include honeybadger:
@@ -46,6 +50,12 @@ begin
 rescue exception
   Honeybadger.notify(exception)
 end
+```
+
+`Honeybadger.notify` can also take a context hash to provide details about when or why an event occurred:
+
+```crystal
+Honeybadger.notify(exception, context: { "user_id" => user.id })
 ```
 
 ## Configuration

--- a/demo/http_context.cr
+++ b/demo/http_context.cr
@@ -1,0 +1,58 @@
+require "http/server"
+require "../src/honeybadger"
+
+class Router
+  include HTTP::Handler
+
+  def initialize
+    @matches = {} of String => Proc(String)
+  end
+
+  def call(context)
+    if route = @matches[context.request.path]?
+      context.response.print route.call
+    else
+      call_next context
+    end
+  end
+
+  def on(path : String, &block : -> String) : Nil
+    @matches[path] = block
+  end
+end
+
+class MyHoneybadgerNotifier < Honeybadger::Handler
+  def context : Honeybadger::ContextHash
+    Honeybadger::ContextHash.new.tap do |c|
+      c["user_id"] = user_id
+    end
+  end
+
+  def user_id
+    23
+  end
+end
+
+router = Router.new
+router.on("/raise") do
+  raise "Broken!"
+end
+
+honeybadger_api_key = ENV["HONEYBADGER_API_KEY"]? || "00000000"
+
+Honeybadger.configure(api_key: honeybadger_api_key)
+
+server = HTTP::Server.new([
+  HTTP::LogHandler.new(Log.for("http.server")),
+  HTTP::ErrorHandler.new,
+  MyHoneybadgerNotifier.new,
+  router
+]) do |http_context|
+  http_context.response.content_type = "text/html"
+  http_context.response.status = HTTP::Status::NOT_FOUND
+  http_context.response.print "<strong>Not found.</strong>"
+end
+
+address = server.bind_tcp 8080
+puts "Listening on http://#{address}"
+server.listen

--- a/script/http_context_demo
+++ b/script/http_context_demo
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Invoke with your honeybadger api key in the environment like this:
+# HONEYBADGER_API_KEY=nnnnnnnn script/demo
+
+set -euo pipefail
+
+crystal build demo/http_context.cr -o bin/http_context --error-trace
+
+bin/http_context &
+server_pid="$!"
+
+sleep 1 # wait for server to listen for requests
+
+curl -s http://localhost:8080/raise
+
+sleep 1 # wait for server to send the payload
+
+kill "$server_pid"

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: honeybadger
-version: 0.1.0
+version: 0.1.1
 
 authors:
   - robacarp

--- a/spec/honeybadger/http_payload_spec.cr
+++ b/spec/honeybadger/http_payload_spec.cr
@@ -6,7 +6,7 @@ describe Honeybadger::HttpPayload do
       expected_request_path = "/honeybadger/crystal"
 
       context = MockHttp.with_request resource: expected_request_path
-      payload = Honeybadger::HttpPayload.new Exception.new, context
+      payload = Honeybadger::HttpPayload.new Exception.new, context.request
       JSON.parse(payload.to_json)["request"]["url"].as_s.should eq expected_request_path
     end
 
@@ -16,7 +16,7 @@ describe Honeybadger::HttpPayload do
         request: MockHttp.build_form_request params: params
       )
 
-      payload = Honeybadger::HttpPayload.new Exception.new, context
+      payload = Honeybadger::HttpPayload.new Exception.new, context.request
       results = JSON.parse(payload.to_json)
 
       params.each do |key, value|
@@ -30,7 +30,7 @@ describe Honeybadger::HttpPayload do
         request: MockHttp.build_multipart_request params: params
       )
 
-      payload = Honeybadger::HttpPayload.new Exception.new, context
+      payload = Honeybadger::HttpPayload.new Exception.new, context.request
       results = JSON.parse(payload.to_json)
 
       params.each do |key, value|
@@ -44,7 +44,7 @@ describe Honeybadger::HttpPayload do
         request: MockHttp.build_json_request params: params
       )
 
-      payload = Honeybadger::HttpPayload.new Exception.new, context
+      payload = Honeybadger::HttpPayload.new Exception.new, context.request
       results = JSON.parse(payload.to_json)
 
       params.each do |key, value|

--- a/spec/honeybadger_spec.cr
+++ b/spec/honeybadger_spec.cr
@@ -31,4 +31,16 @@ describe Honeybadger do
       Honeybadger.api_key.should eq new_api_key
     end
   end
+
+  describe "#notify" do
+    it "allows manually dispatching an erorr" do
+      exception = Honeybadger::ExamplePayload.generate_exception
+      Honeybadger.notify(exception)
+    end
+
+    it "allows specifying the context" do
+      exception = Honeybadger::ExamplePayload.generate_exception
+      Honeybadger.notify(exception, example_context)
+    end
+  end
 end

--- a/spec/honeybadger_spec.cr
+++ b/spec/honeybadger_spec.cr
@@ -41,6 +41,7 @@ describe Honeybadger do
     it "allows specifying the context" do
       exception = Honeybadger::ExamplePayload.generate_exception
       Honeybadger.notify(exception, example_context)
+      Honeybadger.notify(exception, context: example_context)
     end
   end
 end

--- a/spec/spec_helper.cr
+++ b/spec/spec_helper.cr
@@ -1,6 +1,7 @@
 require "spec"
 require "../src/honeybadger"
 
+require "./support/example_context"
 require "./support/example_payload"
 require "./support/mock_http"
 require "./support/protect_configuration"

--- a/spec/support/example_context.cr
+++ b/spec/support/example_context.cr
@@ -1,0 +1,6 @@
+def example_context
+  Honeybadger::ContextHash.new.tap do |context|
+    context["user_id"] = 23
+    context["public_token"] = "12345abc90"
+  end
+end

--- a/spec/support/example_payload.cr
+++ b/spec/support/example_payload.cr
@@ -1,6 +1,7 @@
 module Honeybadger
   class ExamplePayload < Payload
     def initialize(@exception : Exception = self.class.generate_exception)
+      super(@exception)
     end
 
     # Generates an exception with a backtrace for testing.

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -1,7 +1,7 @@
 require "./honeybadger/*"
 
 module Honeybadger
-  VERSION = "0.1.0"
+  VERSION = "0.1.1"
 
   alias ContextHash = Hash(String, String | Int32)
 

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -3,6 +3,8 @@ require "./honeybadger/*"
 module Honeybadger
   VERSION = "0.1.0"
 
+  alias ContextHash = Hash(String, String | Int32)
+
   class Configuration
     # A Honeybadger API key.
     property api_key = ""
@@ -146,5 +148,11 @@ module Honeybadger
 
   def self.notify(exception : Exception) : Nil
     Dispatch.send_async Payload.new(exception)
+  end
+
+  def self.notify(exception : Exception, context : ContextHash) : Nil
+    payload = Payload.new(exception)
+    payload.set_context(context)
+    Dispatch.send_async payload
   end
 end

--- a/src/honeybadger/handler.cr
+++ b/src/honeybadger/handler.cr
@@ -14,11 +14,20 @@ module Honeybadger
     end
 
     # :nodoc:
-    def call(context)
-      response = call_next context
+    def call(http_context)
+      response = call_next http_context
     rescue exception
-      Honeybadger::Dispatch.send_async(@factory.new(exception, context))
+      payload = @factory.new(exception, http_context.request)
+      payload.set_context(context)
+
+      Honeybadger::Dispatch.send_async(payload)
+
       raise exception
+    end
+
+    # Extend to provide helpful data about the context of this request.
+    def context : Honeybadger::ContextHash
+      Honeybadger::ContextHash.new
     end
   end
 end


### PR DESCRIPTION
This is a start at addressing #4.

The json spec for the exceptions API includes the `context` section under the `request`, which is labelled as: "`request` contains information about the HTTP request that caused this exception." As such, the `request` part of the payload isn't rendered unless the payload is being generated by an http middleware which exposes the other components of the `request` schema.

There's a bit of a conflict between that spec and the requested API, which asks for something like this: `Honeybadger.notify("message", context_hash)` which exists outside the call stack of a request. The ruby gem kind of sidesteps this by [rendering the context into the request](https://github.com/honeybadger-io/honeybadger-ruby/blob/master/lib/honeybadger/notice.rb#L227) even when there is no request present, which might mean that this part of the exception API has grown a little outside it's original intent?

I've mirrored the ruby pattern into the parent payload here and extended the higher level request object when it's being rendered as part of an http request.

---------------------

I spent some time digging into the paradigm of thread-local storage for contexts and do not see a way forward. [The unofficial Sentry client](https://github.com/Sija/raven.cr) uses [a mutexed singleton](https://github.com/Sija/raven.cr/blob/master/src/raven/context.cr#L2-L16) which could very well have been inspired by some ruby code similar to the thread local code for Honeybadger.

I didn't try to run a collision test but I don't think the mutexed singleton pattern can work. The crystal http server doesn't fork or thread, [it uses fibers to handle connections](https://github.com/crystal-lang/crystal/blob/dd40a2442/src/http/server.cr#L455-L473). The singleton pattern would certainly work if the crystal server was _forking_ but I doubt it's correctness with threads and fibers. I'm operating under the assumption that all fibers get the same class variable memory, so the singleton is going to be shared between all concurrent requests. I didn't dig into the implementation of fibers to prove that is the case.