### PR TITLE
Improves typing restrictions on the context hash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+- Refactor to open up context API typing to ease implementation (#18)
 
 ## [0.1.1] - 2021-06-29
 ### Added

--- a/spec/honeybadger/context_spec.cr
+++ b/spec/honeybadger/context_spec.cr
@@ -9,7 +9,8 @@ describe "Honeybadger.notify with context" do
       { "user_id" => UUID.random },
       { "user_id" => 23 },
       { 23 => 45 },
-      { "user_age" => 3.14 }
+      { "user_age" => 3.14 },
+      { "user_is_nil" => nil }
     ]
 
     example_contexts.each do |context_hash|

--- a/spec/honeybadger/context_spec.cr
+++ b/spec/honeybadger/context_spec.cr
@@ -1,0 +1,19 @@
+require "../spec_helper"
+require "uuid"
+
+describe "Honeybadger.notify with context" do
+  it "allows specifying a context hash with stringable data types" do
+    exception = Honeybadger::ExamplePayload.generate_exception
+
+    example_contexts = [
+      { "user_id" => UUID.random },
+      { "user_id" => 23 },
+      { 23 => 45 },
+      { "user_age" => 3.14 }
+    ]
+
+    example_contexts.each do |context_hash|
+      Honeybadger.notify(exception, context: context_hash)
+    end
+  end
+end

--- a/spec/support/example_context.cr
+++ b/spec/support/example_context.cr
@@ -1,6 +1,6 @@
 def example_context
   Honeybadger::ContextHash.new.tap do |context|
-    context["user_id"] = 23
+    context["user_id"] = "23"
     context["public_token"] = "12345abc90"
   end
 end

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -3,7 +3,7 @@ require "./honeybadger/*"
 module Honeybadger
   VERSION = "0.1.1"
 
-  alias ContextHash = Hash(String, String | Int32)
+  alias ContextHash = Hash(String, String)
 
   class Configuration
     # A Honeybadger API key.
@@ -150,7 +150,7 @@ module Honeybadger
     Dispatch.send_async Payload.new(exception)
   end
 
-  def self.notify(exception : Exception, context : ContextHash) : Nil
+  def self.notify(exception : Exception, context : Hash) : Nil
     payload = Payload.new(exception)
     payload.set_context(context)
     Dispatch.send_async payload

--- a/src/honeybadger/payload.cr
+++ b/src/honeybadger/payload.cr
@@ -8,10 +8,10 @@ module Honeybadger
     # The exception to be rendered.
     getter exception : Exception
 
-    getter context : ContextHash
-
-    def set_context(context_hash : ContextHash) : Nil
-      @context = context_hash
+    def set_context(context_hash : Hash) : Nil
+      context_hash.each do |key, value|
+        @context[key.to_s] = value.to_s
+      end
     end
 
     # Subclasses of Payload must set @exception, but will likely need to


### PR DESCRIPTION
The typing as implemented on the context hash was buggy, resulting in some weird edge case errors like this:

> In lib/honeybadger/src/honeybadger/payload.cr:14:7
>
> 14 | @context = context_hash
>      ^-------
> Error: instance variable '@context' of Honeybadger::Payload must be Hash(String, Int32 | String), not Hash(String, String)

This loosens up the typing a bit on the setter, but forces a typecast on both keys and values when the context is provided.