### PR TITLE
Allow to be used when the web framework's session doesn't have a `get?` method

### DIFF
--- a/src/honeybadger/authentic_handler.cr
+++ b/src/honeybadger/authentic_handler.cr
@@ -11,7 +11,7 @@ module Honeybadger
     end
 
     def call(context : HTTP::Server::Context)
-      if user_id = context.session.get? @session_key
+      if (session = context.session) && session.responds_to?(:get?) && (user_id = context.session.get?(@session_key))
         Honeybadger.context user_id: user_id
       end
 

--- a/src/honeybadger/authentic_handler.cr
+++ b/src/honeybadger/authentic_handler.cr
@@ -11,7 +11,7 @@ module Honeybadger
     end
 
     def call(context : HTTP::Server::Context)
-      if (session = context.session) && session.responds_to?(:get?) && (user_id = context.session.get?(@session_key))
+      if (session = context.session) && session.responds_to?(:get?) && (user_id = session.get?(@session_key))
         Honeybadger.context user_id: user_id
       end
 


### PR DESCRIPTION
I just upgraded from an older version from before `AuthenticHandler` was added and my app would no longer compile. It turns out it will not build if `context.session` does not have a `get?` method. This appears to be due to the fact that `HTTP::Handler#next` is of type `HTTP::Handler | Nil`, so the type checker checks _all_ classes that include `HTTP::Handler` regardless of whether they're used in the middleware stack.

I think this also means that this shard can't currently be used with any web framework that doesn't monkeypatch a `session` method onto `HTTP::Server::Context`. I'm using [Armature](https://github.com/jgaskins/armature), which does add `session`, but its session type does not have a `get?` method, which is how I experienced this error.

If that's true, I don't think this PR as currently implemented is the correct approach, but it did allow my app to compile.