### PR TITLE
Implements additional signatures / arguments for #notify

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,10 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Pending Release
+## [0.2.2] - 2022-08-26
 ### Added
 - Implements the [filter_keys](https://docs.honeybadger.io/lib/ruby/getting-started/filtering-sensitive-data/) feature. (#27)
 - Implements several additional overloads to Honeybadger.notify. (#29)
+- Adds the `synchronous` named parameter to `Honeybadger.notify`, default is false. (#29)
 ### Fixed
 - AuthenticHandler is no longer required by default. See #28 for details on updating the honeybadger+lucky integration.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## Pending Release
 ### Added
 - Implements the [filter_keys](https://docs.honeybadger.io/lib/ruby/getting-started/filtering-sensitive-data/) feature. (#27)
-### Changed
+- Implements several additional overloads to Honeybadger.notify. (#29)
+### Fixed
 - AuthenticHandler is no longer required by default. See #28 for details on updating the honeybadger+lucky integration.
 
 ## [0.2.1] - 2022-01-20

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: honeybadger
-version: 0.2.1
+version: 0.2.2
 
 authors:
   - robacarp

--- a/spec/honeybadger_spec.cr
+++ b/spec/honeybadger_spec.cr
@@ -45,6 +45,12 @@ describe Honeybadger do
       Honeybadger.notify(exception, context: example_context)
     end
 
+    # This is essentially a compile-time test because there are no easy testing
+    # paradigms to validate that a fiber was spawned.
+    it "allows specifying the behavior to be synchronous" do
+      Honeybadger.notify Honeybadger::ExamplePayload.generate_exception, synchronous: true
+    end
+
     it "allows specifying a context hash with stringable data types" do
       exception = Honeybadger::ExamplePayload.generate_exception
 
@@ -59,6 +65,12 @@ describe Honeybadger do
       example_contexts.each do |context_hash|
         Honeybadger.notify(exception, context: context_hash)
       end
+    end
+
+    it "allows sending a notification with a string" do
+      Honeybadger.notify "notification reason", context: { "user_id" => 23 }
+      Honeybadger.notify "notification reason", error_class: "AnError"
+      Honeybadger.notify "notification reason", synchronous: true
     end
   end
 end

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -7,13 +7,27 @@ module Honeybadger
   alias ContextHash = Hash(String, String)
 
   # Send notifications to the Honeybadger API
-  def self.notify(exception : Exception) : Nil
-    Dispatch.send_async Payload.new(exception)
-  end
+  def self.notify(
+    exception : Exception | String,
+    context : Hash? = nil,
+    *,
+    synchronous : Bool = false,
+    error_class : String? = nil
+  ) : Nil
 
-  def self.notify(exception : Exception, context : Hash) : Nil
-    payload = Payload.new(exception)
-    payload.set_context(context)
-    Dispatch.send_async payload
+    payload = case exception
+      when Exception
+        Payload.new exception
+      when String
+        Payload.new exception, error_class: error_class
+      else
+        raise ArgumentError.new("Invalid exception class, expected a String or Exception")
+      end
+
+    if context
+      payload.set_context context
+    end
+
+    Dispatch.send payload, synchronous: synchronous
   end
 end

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -2,7 +2,7 @@ require "./core_ext/*"
 require "./honeybadger/*"
 
 module Honeybadger
-  VERSION = "0.2.1"
+  VERSION = "0.2.2"
 
   alias ContextHash = Hash(String, String)
 

--- a/src/honeybadger/dispatch.cr
+++ b/src/honeybadger/dispatch.cr
@@ -8,16 +8,16 @@ module Honeybadger
   class Dispatch
     Log = ::Log.for("honeybadger")
 
-    # Sends a payload in a non-blocking way.
-    def self.send_async(payload : Payload) : Nil
-      spawn do
+    # Sends a payload to the reporting api. By default the send is asynchronous
+    # with a fiber.
+    def self.send(payload : Payload, synchronous : Bool = false) : Nil
+      if synchronous
         new(payload).send
+      else
+        spawn do
+          new(payload).send
+        end
       end
-    end
-
-    # Sends a payload to the reporting api.
-    def self.send(payload : Payload) : Nil
-      new(payload).send
     end
 
     # :nodoc:


### PR DESCRIPTION
fixes #5 - adds several features to Honeybadger.notify so that it can be called with a String error instead of an Exception, and the error class optionally specified as well.
fixes #22 - adds the `synchronous` named parameter to `Honeybadger.notify`, default is false.

These are all valid method calls now: 

```crystal
      Honeybadger.notify exception
      Honeybadger.notify exception, context_hash
      Honeybadger.notify exception, context: context_hash
      Honeybadger.notify "notification reason", context: { "user_id" => 23 }
      Honeybadger.notify "notification reason", error_class: "AnError"
      Honeybadger.notify "notification reason", synchronous: true
```
