### PR TITLE
Add support for events for Insights

### DIFF
--- a/spec/honeybadger/event_spec.cr
+++ b/spec/honeybadger/event_spec.cr
@@ -75,6 +75,14 @@ module Honeybadger
       serialized.should contain %{"property":"ExampleEventProperty(@id=123)"}
     end
 
+    it "can delete properties from the event" do
+      event = Event.new(one: 1, two: "two")
+      event["one"]?.should eq 1
+
+      event.delete "one"
+      event["one"]?.should eq nil
+    end
+
     it "merges two events together" do
       first = Event.new(id: 123, name: "first")
       second = Event.new(name: "second")

--- a/spec/honeybadger/event_spec.cr
+++ b/spec/honeybadger/event_spec.cr
@@ -65,7 +65,7 @@ module Honeybadger
       event.to_json.should contain %{"url":"https://example.com"}
     end
 
-    it "converts arbitrary objects into their text representation" do
+    it "converts arbitrary objects into their json representation" do
       event = Event.new(
         property: ExampleEventProperty.new(id: 123),
       )

--- a/spec/honeybadger/event_spec.cr
+++ b/spec/honeybadger/event_spec.cr
@@ -87,5 +87,11 @@ module Honeybadger
       # The second event's non-timestamp properties override that of the first
       data.should contain %{"name":"second"}
     end
+
+    it "can take hashes in the constructor" do
+      event = Event.new({"foo" => "bar"})
+
+      event["foo"].should eq "bar"
+    end
   end
 end

--- a/spec/honeybadger/event_spec.cr
+++ b/spec/honeybadger/event_spec.cr
@@ -1,0 +1,91 @@
+require "../spec_helper"
+
+record ExampleEventProperty, id : Int32
+
+module Honeybadger
+  describe Event do
+    it "sets a timestamp" do
+      event = Event.new
+
+      event.timestamp.should be_a Time
+      event.to_json.should contain %{"ts":"#{event.timestamp.to_rfc3339(fraction_digits: 3)}"}
+    end
+
+    it "can have its timestamp set explicitly" do
+      ts = 1.second.ago
+
+      Event.new(ts).timestamp.should eq ts
+    end
+
+    it "can have properties set" do
+      event = Event.new
+
+      event["name"] = "foo"
+
+      event.to_json.should contain %{"name":"foo"}
+    end
+
+    it "can have properties set at instantiation time" do
+      event = Event.new(name: "foo")
+
+      event.to_json.should contain %{"name":"foo"}
+    end
+
+    it "converts array properties" do
+      event = Event.new(ids: [1, 2, 3])
+
+      event.to_json.should contain %{"ids":[1,2,3]}
+    end
+
+    it "converts nested array properties" do
+      event = Event.new(matrix: [
+        [1, 2, 3],
+        [4, 5, 6],
+        [7, 8, 9],
+      ])
+
+      event.to_json.should contain %{"matrix":[[1,2,3],[4,5,6],[7,8,9]]}
+    end
+
+    it "converts hash properties" do
+      event = Event.new(user: {"id" => 1})
+
+      event.to_json.should contain %{"user":{"id":1}}
+    end
+
+    it "converts nested hash properties" do
+      event = Event.new(order: {"address" => {"zip" => "12345"}})
+
+      event.to_json.should contain %{"order":{"address":{"zip":"12345"}}}
+    end
+
+    it "converts URIs" do
+      event = Event.new(url: URI.parse("https://example.com"))
+
+      event.to_json.should contain %{"url":"https://example.com"}
+    end
+
+    it "converts arbitrary objects into their text representation" do
+      event = Event.new(
+        property: ExampleEventProperty.new(id: 123),
+      )
+
+      serialized = event.to_json
+
+      serialized.should contain %{"property":"ExampleEventProperty(@id=123)"}
+    end
+
+    it "merges two events together" do
+      first = Event.new(id: 123, name: "first")
+      second = Event.new(name: "second")
+
+      data = first.merge(second).to_json
+
+      # Uses the first event's timestamp
+      data.should contain %{"ts":"#{first.timestamp.to_rfc3339(fraction_digits: 3)}"}
+      data.should contain %{"id":123}
+      # The second event's non-timestamp properties override that of the first
+      data.should contain %{"name":"second"}
+    end
+  end
+end

--- a/src/honeybadger.cr
+++ b/src/honeybadger.cr
@@ -30,4 +30,14 @@ module Honeybadger
 
     Dispatch.send payload, synchronous: synchronous
   end
+
+  private EVENT_DISPATCH = EventDispatch.new
+
+  def self.event(**properties)
+    send Event.new(**properties)
+  end
+
+  def self.send(event : Event)
+    EVENT_DISPATCH.send event
+  end
 end

--- a/src/honeybadger/api.cr
+++ b/src/honeybadger/api.cr
@@ -15,8 +15,8 @@ module Honeybadger
     end
 
     # Sends a payload to the exception reporting api endpoint.
-    def send(payload)
-      Response.new request("v1/notices", payload)
+    def send(payload, to path : String = "v1/notices")
+      Response.new request(path, payload)
     end
 
     # :nodoc:

--- a/src/honeybadger/event.cr
+++ b/src/honeybadger/event.cr
@@ -1,0 +1,73 @@
+require "json"
+require "uri"
+
+module Honeybadger
+  struct Event
+    include JSON::Serializable
+    include JSON::Serializable::Unmapped
+
+    @[JSON::Field(key: "ts", converter: Honeybadger::Event::RFC3339Converter)]
+    getter timestamp : Time
+
+    def initialize(@timestamp = Time.utc, **properties)
+      properties.each do |key, value|
+        self[key.to_s] = value
+      end
+    end
+
+    def []=(key : String, value)
+      json_unmapped[key] = coerce(value)
+    end
+
+    def merge(other : self) : self
+      event = self.class.new(timestamp: timestamp)
+
+      json_unmapped.each { |key,value| event[key] = value }
+      other.json_unmapped.each { |key, value| event[key] = value }
+
+      event
+    end
+
+    private def coerce(value : JSON::Any)
+      value
+    end
+
+    private def coerce(value : JSON::Any::Type)
+      JSON::Any.new value
+    end
+
+    private def coerce(value : Array)
+      coerce value.map { |item| coerce item }
+    end
+
+    private def coerce(value : Hash)
+      coerce value.transform_values { |item| coerce item }
+    end
+
+    private def coerce(value : URI)
+      coerce value.to_s
+    end
+
+    # 8-, 16-, and 32-bit integers have to be a special case because the type
+    # checker doesn't know whether to upcast them to Int64 or Float64 for the
+    # JSON::Any::Type case.
+    private def coerce(value : Int)
+      coerce value.to_i64
+    end
+
+    private def coerce(value)
+      # String#inspect_unquoted escapes unprintable characters
+      coerce value.to_s.inspect_unquoted
+    end
+
+    module RFC3339Converter
+      extend self
+
+      def to_json(timestamp : Time, json : JSON::Builder)
+        json.string do |io|
+          timestamp.to_rfc3339 fraction_digits: 3, io: io
+        end
+      end
+    end
+  end
+end

--- a/src/honeybadger/event.cr
+++ b/src/honeybadger/event.cr
@@ -9,7 +9,15 @@ module Honeybadger
     @[JSON::Field(key: "ts", converter: Honeybadger::Event::RFC3339Converter)]
     getter timestamp : Time
 
-    def initialize(@timestamp = Time.utc, **properties)
+    def self.new(**properties)
+      new Time.utc, properties
+    end
+
+    def self.new(properties : Hash)
+      new Time.utc, properties
+    end
+
+    def initialize(@timestamp, properties = NamedTuple.new)
       properties.each do |key, value|
         self[key.to_s] = value
       end
@@ -19,10 +27,12 @@ module Honeybadger
       json_unmapped[key] = coerce(value)
     end
 
+    delegate :[], :[]?, to: json_unmapped
+
     def merge(other : self) : self
       event = self.class.new(timestamp: timestamp)
 
-      json_unmapped.each { |key,value| event[key] = value }
+      json_unmapped.each { |key, value| event[key] = value }
       other.json_unmapped.each { |key, value| event[key] = value }
 
       event

--- a/src/honeybadger/event.cr
+++ b/src/honeybadger/event.cr
@@ -27,7 +27,7 @@ module Honeybadger
       json_unmapped[key] = coerce(value)
     end
 
-    delegate :[], :[]?, to: json_unmapped
+    delegate :[], :[]?, delete, to: json_unmapped
 
     def merge(other : self) : self
       event = self.class.new(timestamp: timestamp)

--- a/src/honeybadger/event_dispatch.cr
+++ b/src/honeybadger/event_dispatch.cr
@@ -1,0 +1,92 @@
+require "./event"
+
+module Honeybadger
+  class EventDispatch
+    # Allow for a spike of events
+    @channel = Channel(Event).new(1 << 16)
+    @buffer = IO::Memory.new
+
+    getter? running = false
+
+    def send(event : Event)
+      ensure_running
+
+      select
+      when @channel.send event
+      else # if the buffer is full, we just skip
+      end
+    end
+
+    private def ensure_running
+      sync { start }
+    end
+
+    private def start
+      return if running?
+
+      @running = true
+      spawn run
+
+      at_exit do
+        # Give the consumer fiber a chance to buffer any further events
+        Fiber.yield
+        send @buffer.to_s
+      end
+    end
+
+    private def run
+      next_event = nil
+
+      loop do
+        buffering = true
+
+        while buffering
+          # If the previous iteration exceeded the buffer cap, we flushed it and
+          # now we need to place it into the fresh buffer
+          if next_event
+            @buffer.puts next_event
+            next_event = nil
+          end
+
+          select
+          when event = @channel.receive
+            # Limits for events endpoint: https://docs.honeybadger.io/api/reporting-events/#limits
+
+            json = event.to_json
+            # Max event size is 100KB
+            if json.bytesize <= 100 * 1024
+              # Maximum payload size is 5MB
+              if @buffer.bytesize + json.bytesize < 5 * 1024 * 1024
+                @buffer.puts json
+                next_event = nil
+              else
+                next_event = json
+                buffering = false
+              end
+            end
+          when timeout(1.second)
+            next_event = nil
+          end
+        end
+
+        # This must be computed outside of the spawned fiber
+        payload = @buffer.to_s
+        spawn send payload
+      ensure
+        @buffer.clear
+      end
+    end
+
+    @mutex = Mutex.new
+
+    def sync
+      @mutex.synchronize { yield }
+    end
+
+    def send(payload : String) : Nil
+      if Honeybadger.report_data?
+        Api.new.send(payload, to: "v1/events")
+      end
+    end
+  end
+end

--- a/src/honeybadger/event_dispatch.cr
+++ b/src/honeybadger/event_dispatch.cr
@@ -79,9 +79,12 @@ module Honeybadger
           end
         end
 
-        # This must be computed outside of the spawned fiber
-        payload = @buffer.to_s
-        spawn send payload
+        unless @buffer.empty?
+          # This must be computed outside of the spawned fiber so that we don't
+          # clear it in the ensure block below before it's been sent.
+          payload = @buffer.to_s
+          spawn send payload
+        end
       ensure
         @buffer.clear
       end


### PR DESCRIPTION
I'm looking to use Insights in one of my apps, so I've created this quick PR to try to add some support for events. This is not complete yet, so I've marked it as draft, but I wanted to get some initial feedback on the approach.

Since Insights supports arbitrary events, I added a `Honeybadger::Event` type that takes arbitrary data and serializes it into JSON. The `ts` key is automatically supported, defaults to the current time, and has nanosecond precision. All other properties, included nested arrays and hashes, are implemented via `JSON::Serializable::Unmapped` and can be provided either in the constructor or via `event[key] = value`.

Since `Honeybadger::Dispatch` is focused on exceptions, I created an `EventDispatch` class specifically for sending events. When you call `Honeybadger.send(event)`, it will buffer events before sending them to the Honeybadger events API. The buffer will continue until either 5MB of events have been collected or 1 second has passed, whichever comes first.

A few other things I'd like to do here:
- Subscribe to an instrumentation framework for common operations, a la `ActiveSupport::Notifications`
  - Does [Pulsar](https://github.com/luckyframework/pulsar) work for this?
- Reuse `HTTP::Client`s between reports to the API

Open questions
- [ ] What do we do if an event exceeds 100KB? I feel like there should be a warning for this, but I'm not sure how to surface that. Logging it seems … cyclic. 😄
- [x] I've implemented nanosecond precision for `ts`, but only because that's what OTel prescribes. Is that overkill for Insights?
  - **Using millisecond precision**